### PR TITLE
Add: アカウントのメール認証設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: "track-field.onrender.com", protocpl: "https" }
+  config.action_mailer.default_url_options = { host: "track-field.onrender.com", protocol: "https" }
   config.action_mailer.delivery_method =:smtp
   config.action_mailer.smtp_settings = {
     address: "smtp.gmail.com",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,14 +78,14 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: 'track-field.onrender.com', protocpl: 'https'}
-  cofig.action_mailer.delivery_method =:smtp
-  cofig.action_mailer.smtp_settiongs = {
-    address: 'smtp.gmail.com',
+  config.action_mailer.default_url_options = { host: "track-field.onrender.com", protocpl: "https" }
+  config.action_mailer.delivery_method =:smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
     port: 587,
-    domain: 'track-field.onrender.com'
-    user_name: ENV['GMAIL_USERNAME'],
-    password: ENV['GMAIL_PASSWORD'],
+    domain: "track-field.onrender.com",
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_PASSWORD"],
     authentication: :plain,
     enable_starttls_auto: true
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,18 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: 'track-field.onrender.com', protocpl: 'https'}
+  cofig.action_mailer.delivery_method =:smtp
+  cofig.action_mailer.smtp_settiongs = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'track-field.onrender.com'
+    user_name: ENV['GMAIL_USERNAME'],
+    password: ENV['GMAIL_PASSWORD'],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
### 概要
***
deviseの :confirmableモジュールを使用して、ユーザー認証のメール送信機能を実装しました。

### 変更内容
***
- メール送信設定をdevelopment環境に合わせて設定
- ユーザー登録時に確認メールを送信し、リンクをクリックすることでサインインが可能になる。

### 確認方法
***
1. ユーザー登録時に有効なメールアドレスを入力
2. 登録したメールアドレスを宛てに認証メールが届く
3. メール本文内のリンクをクリックし、ログイン画面からサインインできることを確認