### PR TITLE
Add: Topページ作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,3 @@
+class StaticPagesController < ApplicationController
+    def top; end
+end

--- a/app/helpers/static_page_helper.rb
+++ b/app/helpers/static_page_helper.rb
@@ -1,0 +1,2 @@
+module StaticPageHelper
+end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,4 @@
+<div class="text- flex justify-center space-x-4 items-center text-lg font-bold h-screen  border">
+  <%= link_to "ログイン", new_user_session_path, class:  "px-6 py-3 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600 transition" %><br />
+  <%= link_to "新規登録", new_user_registration_path, class: "px-6 py-3 bg-orange-500 text-white rounded-lg shadow-md hover:bg-orange-600 transition" %><br />
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root "posts#index"
+  root "static_pages#top"
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"

--- a/test/controllers/static_page_controller_test.rb
+++ b/test/controllers/static_page_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StaticPageControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
***
- これまでURLにアクセスすると、投稿画面に遷移していたのを、TOPページに遷移するようにしました。

### 変更内容
***
- `StaticPagesController`コントローラーの作成し、`top`アクションを追加
- `views/static_pages/top.html.erb`を作成し、topページのビューを追加
- `views/static_pages/top.html.erb`にログイン、新規登録ボタンを追加
- `routes.rb`のrootを `posts#index` から`static_pages#top`に変更

### 確認方法
***
ブラウザでURLにアクセスし、TOPページが表示されること確認。