### PR TITLE
Mypage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  def after_sign_in_path_for(resource)
+    if current_user.profile&.name.nil?
+      new_profile_path
+    else
+      posts_path
+    end
+  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,3 @@
+class ProfilesController < ApplicationController
+
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,3 +1,41 @@
 class ProfilesController < ApplicationController
+  before_action :set_profile, only: [:edit, :update, :show]
 
+  def show
+  end
+
+  def new
+    @profile = Profile.new
+  end
+
+  def create
+    @profile = Profile.new(profile_params)
+
+    if @profile.save
+      redirect_to @profile, notice: "プロフィールが作成されました！"
+    else
+      render new_profile_path, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @profile.update(profile_params)
+      redirect_to @profile, notice: "プロフィールが更新されました！"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_profile
+      @profile = current_user.profile
+  end
+
+  def  profile_params
+    params.require(:profile).permit(:name, :icon, :areas, :event, :goal, :self_introduction).merge(user_id: current_user.id)
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,3 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,5 @@
 class Profile < ApplicationRecord
   belongs_to :user
+
+  validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable
+
+  has_one :profile
 end

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_with(model: @profile, html: { class: "space-y-4" }) do |f| %>
+  <div class="flex flex-col items-start">
+    <%= f.label :name, class: "text-lg font-medium mb-2" %>
+    <%= f.text_field :name, class: "border border-gray-500 text-lg p-2 w-full rounded-md" %>
+  </div>
+
+  <div class="flex flex-col items-start">
+    <%= f.label :icon, class: "text-lg font-medium mb-2" %>
+    <%= f.text_field :icon, class: "border border-gray-500 text-lg p-2 w-full rounded-md" %>
+  </div>
+
+  <div class="flex flex-col items-start">
+    <%= f.label :areas, class: "text-lg font-medium mb-2" %>
+    <%= f.text_field :areas, class: "border border-gray-500 text-lg p-2 w-full rounded-md" %>
+  </div>
+
+  <div class="flex flex-col items-start">
+    <%= f.label :event, class: "text-lg font-medium mb-2" %>
+    <%= f.text_field :event, class: "border border-gray-500 text-lg p-2 w-full rounded-md" %>
+  </div>
+
+  <div class="flex flex-col items-start">
+    <%= f.label :goal, class: "text-lg font-medium mb-2" %>
+    <%= f.number_field :goal, step: "0.1", class: "border border-gray-500 text-lg p-2 w-full rounded-md" %>
+  </div>
+
+  <div class="flex flex-col items-start">
+    <%= f.label :self_introduction, class: "text-lg font-medium mb-2" %>
+    <%= f.text_area :self_introduction, class: "border border-gray-500 text-lg p-2 w-full rounded-md h-32" %>
+  </div>
+
+  <div class="flex justify-center">
+    <%= f.submit "submit", class: "px-6 py-3 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600 transition" %>
+  </div>
+
+<% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,5 @@
+<h1 class="text-center text-lg font-bold">
+  プロフィール変更
+</h1>
+
+<%= render "form" %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,0 +1,5 @@
+<h1 class="text-center text-lg font-bold">
+  プロフィール設定
+</h1>
+
+<%= render "form" %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,12 @@
+<h1> プロフィール </h1>
+
+<div>名前：<%= current_user.profile.name %></div>
+<div>所属地：<%= current_user.profile.areas %></div>
+<div>専門種目：<%= current_user.profile.event %></div>
+<div>目標：<%= current_user.profile.goal %></div>
+<div>自己紹介：<%= current_user.profile.self_introduction %></div>
+
+<%= link_to '編集', edit_profile_path(@profile) %>
+
+<br>
+<%= link_to '投稿一覧へ', posts_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   resources :posts
+  resources :profiles, only: [:new, :create, :show, :edit, :update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250203074219_create_profiles.rb
+++ b/db/migrate/20250203074219_create_profiles.rb
@@ -1,0 +1,15 @@
+class CreateProfiles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+      t.string :icon
+      t.string :areas
+      t.string :event
+      t.float :goal
+      t.text :self_introduction
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_30_214902) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_03_074219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,19 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_214902) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name"
+    t.string "icon"
+    t.string "areas"
+    t.string "event"
+    t.float "goal"
+    t.text "self_introduction"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -35,4 +48,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_214902) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "profiles", "users"
 end

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  name: MyString
+  icon: MyString
+  areas: MyString
+  event: MyString
+  goal: 1.5
+  self-introduction: MyText
+
+two:
+  user: two
+  name: MyString
+  icon: MyString
+  areas: MyString
+  event: MyString
+  goal: 1.5
+  self-introduction: MyText

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfileTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
***
- プロフィール機能を実装しました。

### 変更内容
***
- `Profile`モデル、テーブルの追加
- `profile`用の`Controller`と関連するビュー(`show/new/edit`)を作成
- `application_controller`に`before_action`を設定し、プロフィール未設定時にプロフィール設定画面に遷移するように変更
- `User`モデルと`Profile`モデルにアソシエーション関係に設定
- `routes`に`resources :profiles, only: [:new, :create, :edit, :update, :show]`を追加
- `profile`モデルに`name`にバリデーションを追加

### 確認方法
***

1. 新規登録後、プロフィール設定画面に`/profile/new`に遷移することを確認
2. プロフィール登録後、`/profile/:id`で詳細画面に遷移することを確認
3.`/profile/edit/:id`で編集画面に遷移しプロフィールを編集できることを確認

### 関連ISSUE
- closed #27