### PR TITLE
認証画面のレイアウト修正

### DIFF
--- a/app/views/competition_results/index.html.erb
+++ b/app/views/competition_results/index.html.erb
@@ -1,4 +1,3 @@
-<p style="color: green"><%= notice %></p>
 <div class="text-3xl text-center justify-center">
 試合結果一覧
 </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,18 @@
-<h2>Resend confirmation instructions</h2>
+<div class="flex flex-col items-center h-screen pt-24 space-y-6 text-lg font-bold border">
+  <h2 class="text-2xl text-gray-800">確認メールを再送信</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "bg-white p-6 rounded-lg shadow-md w-96" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :email, "登録したメールアドレス", class: "block text-gray-700 font-bold mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@mail.com", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
+    <div class="mt-4">
+      <%= f.submit "確認メールを再送信", class: "w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg shadow-md transition duration-300" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,18 @@
-<h2>Forgot your password?</h2>
+<div class="flex flex-col items-center h-screen  pt-24 space-y-6 text-lg font-bold border">
+  <h2 class="text-2xl text-gray-800">パスワードをお忘れですか？</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "bg-white p-6 rounded-lg shadow-md w-96" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :email, "登録したメールアドレス", class: "block text-gray-700 font-bold mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@mail.com", class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
+    <div class="mt-4">
+      <%= f.submit "パスワード再設定メールを送信", class: "w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg shadow-md transition duration-300" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,31 @@
-<h2>Sign up</h2>
+<div class="flex flex-col items-center h-screen pt-24 space-y-6 text-lg font-bold border">
+  <h2 class="text-2xl text-gray-800">新規登録</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "bg-white p-6 rounded-lg shadow-md w-96" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :email, class: "block text-gray-700 font-bold mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@mail.com" , class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :password, class: "block text-gray-700 font-bold mb-2" %>
+      <% if @minimum_password_length %>
+        <em class="text-sm text-gray-500">(<%= @minimum_password_length %> 文字以上)</em>
+      <% end %>
+      <%= f.password_field :password, autocomplete: "new-password", placeholder: "password", class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :password_confirmation, class: "block text-gray-700 font-bold mb-2" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "password", class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
+    <div class="mt-4">
+      <%= f.submit "登録", class: "w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-3 px-6 rounded-lg shadow-md transition duration-300" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,30 @@
-<h2>Log in</h2>
+<div class="flex flex-col items-center h-screen pt-24 space-y-6 text-lg font-bold border">
+  <h2 class="text-2xl text-gray-800">ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "bg-white p-6 rounded-lg shadow-md w-96" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :email, class: "block text-gray-700 font-bold mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@mail.com", class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+    <div class="mb-4">
+      <%= f.label :password, class: "block text-gray-700 font-bold mb-2" %>
+      <%= f.password_field :password, autocomplete: "current-password", placeholder: "password", class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
+
+    <% if devise_mapping.rememberable? %>
+      <div class="mb-4 flex items-center">
+        <%= f.check_box :remember_me, class: "mr-2" %>
+        <%= f.label :remember_me, class: "text-gray-700" %>
+      </div>
+    <% end %>
+
+    <div class="mt-4">
+      <%= f.submit "ログイン", class: "w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg shadow-md transition duration-300" %>
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mt-4">
+    <h2 class="font-semibold text-xl">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="list-disc pl-6">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,17 +1,17 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "新規登録", new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードをお忘れの方はこちら", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "確認メールが届かない方はこちら", new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,19 @@
 
   <body>
     <%= render 'shared/header' %>
+
+    <% if notice.present?%>
+      <div class="flex justify-center">
+        <p class="notice text-center bg-green-400 rounded px-4 py-2"><%= notice %></p>
+      </div>
+    <% end %>
+
+    <% if alert.present?%>
+      <div class="flex justify-center">
+        <p class="alert text-center text-white bg-red-400 rounded px-4 py-2"><%= alert %></p>
+      </div>
+    <% end %>
+
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,3 @@
-<p style="color: green"><%= notice %></p>
-
 <% content_for :title, "Posts" %>
 
 <h1 class="text-center text-3xl relative">投稿一覧</h1>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,3 @@
-<p class="text-green-500 mb-4"><%= notice %></p>
-
 <div class="max-w-3xl mx-auto p-6 bg-white shadow-lg rounded-lg my-6">
   <%= render @post %>
 


### PR DESCRIPTION
### 概要
***
認証画面が初期状態のままだったため、最低限のレイアウトを実装しました。

### 変更内容
***
- 新規登録、ログイン、パスワード忘れ、確認メール再送信画面のレイアウトを調整
- フラッシュメッセージを中央に配置

### 確認方法
***

1. 以下の画面でレイアウトが適用されていることを確認
`/users/sign_up`（新規登録）
`/users/sign_in`（ログイン）
`/users/password/new`（パスワード忘れ）
`/users/confirmation/new`（確認メール再送信）
2. 入力エラー時に、エラーメッセージが適切に表示されることを確認
3. ログイン後、フラッシュメッセージが中央に表示されることを確認

### 関連ISSUE
***