### PR TITLE
投稿に内容フォームの追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,10 +6,12 @@ class PostsController < ApplicationController
   # GET /posts or /posts.json
   def index
     @posts = Post.includes(user: :profile).order(created_at: :desc)
+    @show_page = false
   end
 
   # GET /posts/1 or /posts/1.json
   def show
+    @show_page = true
   end
 
   # GET /posts/new
@@ -47,9 +49,7 @@ class PostsController < ApplicationController
   def destroy
     @post.destroy!
 
-    respond_to do |format|
-      format.html { redirect_to posts_path, status: :see_other, notice: "投稿が削除されました！" }
-    end
+    redirect_to posts_path, status: :see_other, notice: "投稿が削除されました！"
   end
 
   private
@@ -60,7 +60,7 @@ class PostsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def post_params
-      params.require(:post).permit(:title, :image)
+      params.require(:post).permit(:title, :image, :content)
     end
 
     def correct_post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,5 @@ class Post < ApplicationRecord
     belongs_to :user
 
     validates :title, presence: true
+    validates :content, presence: true
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,7 +3,7 @@
 
   <div class="mb-4">
     <%= form.label :title, class: "block text-lg font-semibold mb-2" %>
-    <%= form.text_field :title, class: "w-full p-2 border border-gray-300 rounded-md" %>
+    <%= form.text_field :title, placeholder: 'タイトルを入力', class: "w-full p-2 border border-gray-300 rounded-md" %>
   </div>
 
   <div class="mb-4">
@@ -11,7 +11,12 @@
       <%= image_tag post.image, class: "rounded" %>
     <% end %>
     <%= form.label :image, class: "block text-lg font-semibold mb-2" %>
-    <%= form.file_field :image, class: "w-full p-2 border border-gray-300 rounded-md" %>
+    <%= form.file_field :image, accept: 'image/jpeg,image/png,image/gif',  class: "w-full p-2 border border-gray-300 rounded-md" %>
+  </div>
+
+  <div class="mb-4">
+    <%= form.label :content, class: "block text-lg font-semibold mb-2" %>
+    <%= form.text_field :content, placeholder: '内容を入力', class: "w-full p-2 border border-gray-300 rounded-md" %>
   </div>
 
   <div class="mt-6 text-center">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -14,5 +14,8 @@
     <strong>タイトル:</strong>
     <%= post.title %>
     <br>
+    <strong>内容:</strong>
+    <%= @show_page ? post.content : truncate(post.content, length: 15) %>
+    <br>
 
 </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Editing post" %>
+<%= link_to '←', post_path(@post), class: "text-3xl" %>
 
 <div class="max-w-3xl mx-auto p-6 bg-white shadow-lg rounded-lg my-6">
   <h1 class="text-3xl font-bold text-center mb-6">編集</h1>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,12 +10,12 @@
 <div id="posts" class="container mx-auto px-4 md:px-12 pb-16">
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
     <% @posts.each do |post| %>
-      <div class="border border-gray-300 rounded-lg bg-white shadow-md p-4">
+      <div class="border border-gray-300 rounded-lg bg-white shadow-md p-4 relative min-h-[150px]">
         <%= render post %>
         <% if post.image.attached? %>
           <%= image_tag post.image.variant(resize_and_pad: [100, 100]).processed, class: "item-center" %>
         <% end %>
-        <p class="text-right mt-4">
+        <p class="text-right absolute bottom-4 right-4">
           <%= link_to "詳細", post, class: "py-1 px-2 rounded bg-blue-400 text-white" %>
         </p>
       </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "New Post" %>
+<%= link_to '←', posts_path, class: "text-3xl" %>
 
 <div class="max-w-4xl mx-auto p-6 bg-white shadow-lg rounded-lg">
   <h1 class="text-2xl font-bold text-center mb-6">新しい投稿</h1>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,9 @@
     <% end %>
       <%= link_to "投稿一覧へ", posts_path, class: "text-blue-500 hover:text-blue-700 mx-2" %>
     <% if @post.user.id == current_user.id %>
-      <%= button_to "削除", @post, method: :delete, data: { confirm: "削除してよろしいですか？" },  class: "bg-red-500 text-white py-2 px-4 rounded-lg mt-4 hover:bg-red-600 transition" %>
+      <br>
+      <br>
+      <%= link_to "削除", post_path, data: { 'turbo-method': :delete, turbo_confirm: "削除してよろしいですか？" }, class: "bg-red-500 text-white py-2 px-4 rounded-lg mt-4 hover:bg-red-600 transition" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,8 +1,8 @@
 <% if object.errors.any? %>
   <div class="alert alert-danger">
-    <ul class="mb-0">
+    <ul class="mb-0 bg-red-400 inline-block max-w-full">
       <% object.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
+        <li>・<%= msg %></li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,6 +43,7 @@ ja:
       post:
         title: タイトル
         image: 画像
+        content: 内容
   activemodel:
     attributes:
       competition_result_form:

--- a/db/migrate/20250319061236_add_content_to_post.rb
+++ b/db/migrate/20250319061236_add_content_to_post.rb
@@ -1,0 +1,5 @@
+class AddContentToPost < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :content, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_14_142349) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_19_061236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_142349) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.text "content", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
***
投稿機能に「内容（content）」の入力フォームを追加を実装

### 変更内容
***
- `posts` テーブルに `content` カラムを追加  
- `_form.html.erb` に `content` 入力欄を追加  
- `content` を必須項目に設定（バリデーション追加）  

### 確認方法
***
1. 投稿フォームに `content` 入力欄が表示されていることを確認  
2. `content` を空のまま投稿すると、エラーメッセージが表示されることを確認  
3. 正常に投稿できることを確認  
