### PR TITLE
投稿にいいね機能の追加

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,39 @@
+class LikesController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_post, only: [ :create, :destroy ]
+
+  def create
+      @post_like = Like.find_or_create_by(user_id: current_user.id, post_id: @post.id)
+
+    if @post_like
+      @post_like.save!
+      render turbo_stream: turbo_stream.replace(
+        "like_button_#{@post.id}",
+        partial: "likes/like_button",
+        locals: { post: @post, like: true },
+      )
+    else
+      redirect_to @post
+    end
+  end
+
+  def destroy
+    @post_like = Like.find_by(user_id: current_user.id, post_id: @post.id)
+
+    if @post_like
+      @post_like.destroy!
+
+      render turbo_stream: turbo_stream.replace(
+          "like_button_#{@post.id}",
+          partial: "likes/like_button",
+          locals: { post: @post, like: false },
+        )
+    else
+        redirect_to @post
+    end
+  end
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,13 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: [ :liked_posts ]
+
+  def liked_posts
+    @like_posts = current_user.likes.includes(:post).map(&:post)
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+    belongs_to :user
+    belongs_to :post
+
+    validates :post_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,13 @@
 class Post < ApplicationRecord
     has_one_attached :image
     belongs_to :user
+    has_many :likes, dependent: :destroy
 
     validates :title, presence: true
     validates :content, presence: true
+
+
+    def like?(user)
+        likes.where(user_id: user.id).exists?
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   has_one :profile
   has_many :posts
   has_many :competition_results
+  has_many :likes, dependent: :destroy
 end

--- a/app/views/likes/_like_button.html.erb
+++ b/app/views/likes/_like_button.html.erb
@@ -1,0 +1,15 @@
+<turbo-frame id="like_button_<%= post.id %>">
+  <div class="w-full flex justify-end">
+    <% if post.like?(current_user) %>
+        <%= link_to post_like_path(post.id), method: :delete, data: { 'turbo-method': :delete} do %>
+        <span style="color:red;">♥</span>
+        <%= post.likes.count %>
+        <% end %>
+    <% else %>
+        <%= link_to post_like_path(post.id), method: :post, data: { 'turbo-method': :post} do %>
+        <span>♡</span>
+        <%= post.likes.count %>
+        <% end %>
+    <% end %>
+  </div>
+</turbo-frame>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,15 +1,18 @@
 <div id="<%= dom_id post %>">
-  <div class="flex items-center mb-2">
+  <div class="flex items-center justify-between mb-2">
     <%if post.user&.profile&.avatar&.attached? %>
       <%= image_tag post.user&.profile.avatar, class:"rounded-full w-8 h-8 object-cover" %>
     <% else %>
       <%= image_tag 'default.png', class:"rounded-full w-8 h-8 object-cover" %>
     <% end %>
     <% if post.user&.profile&.name.present? %>
-      <p><%= post.user.profile.name %></p>
+      <p class="ml-2 whitespace-nowrap"><%= post.user.profile.name %></p>
     <% else %>
       <p>名前が未設定です</p>
     <% end %>
+
+    <%= render 'likes/like_button', post: post, like?: post.like?(current_user) %>
+
   </div>
     <strong>タイトル:</strong>
     <%= post.title %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -37,7 +37,13 @@
     <%= link_to '編集', edit_profile_path(@profile), class: "inline-block bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 transition" %>
   </div>
 </div>
-
+<br>
+<div data-controller="select-event" class="bg-white shadow-lg rounded-lg p-6 w-full max-w-lg mx-auto">
+  <h2 class="text-xl font-bold text-center border-b pb-2 mb-4">いいねを送った投稿</h2>
+    <div class="flex gap-2 items-center justify-center">
+      <%= link_to "一覧へ", liked_posts_user_path(@user)  ,class: "font-semibold inline-block bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 transition" %>
+    </div>
+</div>
 <br>
 
 <div data-controller="select-event" class="bg-white shadow-lg rounded-lg p-6 w-full max-w-lg mx-auto">

--- a/app/views/users/liked_posts.html.erb
+++ b/app/views/users/liked_posts.html.erb
@@ -1,0 +1,22 @@
+<h2 class="text-center text-3xl mb-4">いいねを送った投稿一覧</h2>
+<div id="posts" class="container mx-auto px-4 md:px-12 pb-16">
+  <div class="flex justify-center mt-8">
+    <% if @like_posts.present? %>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <% @like_posts.each do |post| %>
+          <div class="border border-gray-300 rounded-lg bg-white shadow-md p-4 relative min-h-[150px]">
+            <%= render "posts/post", post: post %>
+            <% if post.image.attached? %>
+              <%= image_tag post.image.variant(resize_and_pad: [100, 100]).processed, class: "item-center" %>
+            <% end %>
+            <p class="text-right absolute bottom-4 right-4">
+              <%= link_to "詳細", post, class: "py-1 px-2 rounded bg-blue-400 text-white" %>
+            </p>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-gray-500 text-center">投稿にいいねを送るとこのページに表示されます。</p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,14 @@
 Rails.application.routes.draw do
+  get "users/show"
+  get "users/likes"
   devise_for :users
+
+  resources :users do
+    member do
+      get :liked_posts
+    end
+  end
+
   resources :posts do
     resource :like, only: [ :create, :destroy ]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :posts
+  resources :posts do
+    resource :like, only: [ :create, :destroy ]
+  end
+
   resources :profiles, only: [ :new, :create, :show, :edit, :update ] do
     collection do
       get :fetch_data

--- a/db/migrate/20250322025839_create_likes.rb
+++ b/db/migrate/20250322025839_create_likes.rb
@@ -1,0 +1,9 @@
+class CreateLikes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_19_061236) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_22_025839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_19_061236) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["middle_and_long_id"], name: "index_lap_times_on_middle_and_long_id"
+  end
+
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "middle_and_longs", force: :cascade do |t|
@@ -145,6 +154,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_19_061236) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "competition_results", "users"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"
   add_foreign_key "sprints", "competition_results"

--- a/test/controllers/likes_controller_test.rb
+++ b/test/controllers/likes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LikesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get users_show_url
+    assert_response :success
+  end
+
+  test "should get likes" do
+    get users_likes_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LikesTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
***
投稿に「いいね」機能を追加し、プロフィール画面から「いいね一覧」を確認できる機能を実装しました。

### 変更内容
***

**いいね機能**
- `likes`テーブルを作成し、`user_id`と`post_id`をカラムとして設定
- `like`モデルを作成し、`user`モデル`とpost`モデルのアソシエーションを設定
- turbo_stream を活用し、いいねボタンとカウントの非同期更新を実装
- `post`に関連するため、`post`をネストして`like`をルーティング設定

**いいね一覧ページ追加**
- プロフィール画面に「いいね一覧」ページのリンクを設置
- `user#likes`アクションを追加し、自身がいいねした投稿を取得する処理を実装
- いいね一覧ページで、ユーザーが「いいね」した投稿の一覧を表示

### 確認方法
***
**いいね機能の確認**

1. 投稿一覧または詳細画面で「いいね」ボタンを押す
2. ボタンの色が変わり、カウントが1増えることを確認
3. もう一度「いいね」ボタンを押すと、色が元に戻りカウントが減ることを確認

**いいね一覧ページの確認**

1. プロフィール画面へ移動
2. いいねを送った投稿一覧 へのリンクをクリック
3. いいねした投稿の一覧が正しく表示されることを確認

### 関連ISSUE
***
#24 