### PR TITLE
レイアウト修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,7 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_profile, only: [ :edit, :update, :show ]
+  before_action :event_type, only: [ :new, :create, :show, :edit, :update ]
 
   def show
     @user = Profile.find(params[:id])
@@ -66,5 +67,9 @@ class ProfilesController < ApplicationController
 
   def  profile_params
     params.require(:profile).permit(:name, :icon, :areas, :event, :goal, :self_introduction, :avatar).merge(user_id: current_user.id)
+  end
+
+  def event_type
+    @event_type = CompetitionResult.event_types.keys.map { |k| [ I18n.t("enums.competition_result.event_type.#{k}"), k ] }
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,6 @@ class UsersController < ApplicationController
   private
 
   def set_user
-    @user = User.find(params[:id])
+    @user = current_user
   end
 end

--- a/app/views/competition_results/_form.html.erb
+++ b/app/views/competition_results/_form.html.erb
@@ -45,28 +45,28 @@
 
       <div class="form sprint grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :sprint_record, 'タイム', class: "mr-4" %>
-        <%= f.number_field :sprint_record, step: "0.01", placeholder: "タイムを入力", class: "border border-gray-300 p-1 rounded sprint-field" %>
+        <%= f.number_field :sprint_record, step: "0.01", placeholder: "例: 11.11", class: "border border-gray-300 p-1 rounded sprint-field" %>
       </div>
 
       <div class="form sprint grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :sprint_wind_speed, '風速', class: "mr-4" %>
-        <%= f.number_field :sprint_wind_speed, step: "0.1", placeholder: "風速を入力" , class: "border border-gray-300 p-1 rounded sprint-field" %>
+        <%= f.number_field :sprint_wind_speed, step: "0.1", placeholder: "例: 1.0" , class: "border border-gray-300 p-1 rounded sprint-field" %>
       </div>
 
       <div class="form middle-and-long grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :middle_and_long_record, 'タイム', class: "mr-4" %>
-        <%= f.number_field :middle_and_long_record, step: "0.01", placeholder: "タイムを入力" , class: "border border-gray-300 p-1 rounded middle-and-long-field" %>
+        <%= f.number_field :middle_and_long_record, step: "0.01", placeholder: "例: 119.99" , class: "border border-gray-300 p-1 rounded middle-and-long-field" %>
       </div>
 
       <div class="lap-time-area">
         <div class="form middle-and-long grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
           <%= f.label :lap_distance, '距離', class: "mr-4" %>
-          <%= f.number_field :lap_distance, placeholder: "ラップの距離を入力" , class: "border border-gray-300 p-1 rounded middle-and-long-field" %>
+          <%= f.number_field :lap_distance, placeholder: "例: 400" , class: "border border-gray-300 p-1 rounded middle-and-long-field" %>
         </div>
 
         <div class="form middle-and-long grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
           <%= f.label :lap_time, 'ラップタイム', class: "mr-4" %>
-          <%= f.number_field :lap_time, step: "0.01", placeholder: "ラップタイムを入力" , class: "border border-gray-300 p-1 rounded middle-and-long-field" %>
+          <%= f.number_field :lap_time, step: "0.01", placeholder: "例: 55.99" , class: "border border-gray-300 p-1 rounded middle-and-long-field" %>
         </div>
       </div>
 
@@ -77,28 +77,28 @@
 
       <div class="form jumping grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :jumping_record, '記録', class: "mr-4" %>
-        <%= f.number_field :jumping_record, step: "0.01", placeholder: "記録を入力" , class: "border border-gray-300 p-1 rounded jumping-field" %>
+        <%= f.number_field :jumping_record, step: "0.01", placeholder: "例: 7.00" , class: "border border-gray-300 p-1 rounded jumping-field" %>
       </div>
 
       <div class="form jumping grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :jumping_wind_speed, '風速', class: "mr-4" %>
-        <%= f.number_field :jumping_wind_speed, step: "0.1", placeholder: "風速を入力" , class: "border border-gray-300 p-1 rounded jumping-field" %>
+        <%= f.number_field :jumping_wind_speed, step: "0.1", placeholder: "例: 1.0" , class: "border border-gray-300 p-1 rounded jumping-field" %>
       </div>
 
       <div class="form jumping grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :jumping_approach_distance, '助走距離', class: "mr-4" %>
-        <%= f.number_field :jumping_approach_distance, step: "0.01", placeholder: "助走距離を入力" ,  class: "border border-gray-300 p-1 rounded jumping-field" %>
+        <%= f.number_field :jumping_approach_distance, step: "0.01", placeholder: "例: 23.55" ,  class: "border border-gray-300 p-1 rounded jumping-field" %>
       </div>
 
       <div class="form throwing grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :throwing_record, '記録', class: "mr-4" %>
-        <%= f.number_field :throwing_record, step: "0.01", placeholder: "記録を入力" ,  class: "border border-gray-300 p-1 rounded throwing-field" %>
+        <%= f.number_field :throwing_record, step: "0.01", placeholder: "例: 30.15" ,  class: "border border-gray-300 p-1 rounded throwing-field" %>
       </div>
 
 
       <div class="form throwing grid grid-cols-2  items-center" style="visibility: hidden; position: absolute;">
         <%= f.label :throwing_approach_distance, '助走距離', class: "mr-4" %>
-        <%= f.number_field :throwing_approach_distance, placeholder: "助走距離を入力" , step: "0.01",  class: "border border-gray-300 p-1 rounded throwing-field" %>
+        <%= f.number_field :throwing_approach_distance, placeholder: "例: 20.55" , step: "0.01",  class: "border border-gray-300 p-1 rounded throwing-field" %>
       </div>
 
       <div class="grid grid-cols-2  items-center">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -2,7 +2,7 @@
 
   <div class="flex flex-col items-start space-y-2">
     <%= f.label :name, class: "text-lg font-medium" %>
-    <%= f.text_field :name, class: "border border-gray-300 text-base p-2 w-full rounded-md" %>
+    <%= f.text_field :name, placeholder: "名前またはニックネームでも可",  class: "border border-gray-300 text-base p-2 w-full rounded-md" %>
   </div>
 
   <div>
@@ -22,12 +22,12 @@
 
   <div class="flex flex-col items-start space-y-2  mt-10">
     <%= f.label :areas, class: "text-lg font-medium" %>
-    <%= f.text_field :areas, class: "border border-gray-300 text-base p-2 w-full rounded-md" %>
+    <%= f.text_field :areas, placeholder: "例： 東京",  class: "border border-gray-300 text-base p-2 w-full rounded-md" %>
   </div>
 
   <div class="flex flex-col items-start space-y-2">
     <%= f.label :event, class: "text-lg font-medium" %>
-    <%= f.text_field :event, class: "border border-gray-300 text-base p-2 w-full rounded-md" %>
+    <%= f.select :event, @event_type, {include_blank: '専門種目を選択してください' }, { class: 'border border-gray-300 p-1 rounded' } %>
   </div>
 
   <div class="flex flex-col items-start space-y-2">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,7 @@
 <div class="bg-white shadow-lg rounded-lg p-6 w-full max-w-lg mx-auto mt-4">
-  <%= link_to "ログアウト", destroy_user_session_path, data: { 'turbo-method': :delete}, class: "" %>
+  <div class="flex justify-center mb-4">
+    <%= link_to "ログアウト", destroy_user_session_path, data: { 'turbo-method': :delete }, class: "bg-red-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 transition" %>
+  </div>
   <h2 class="text-xl font-bold text-center border-b pb-2 mb-4">プロフィール</h2>
 
   <div class="space-y-4">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -23,11 +23,15 @@
     </div>
     <div class="flex gap-2 items-center">
       <span class="font-semibold">専門種目：</span>
-      <span><%= current_user.profile.event %></span>
+      <span><%= I18n.t("enums.competition_result.event_type.#{current_user.profile.event}") %></span>
     </div>
     <div class="flex gap-2 items-center">
       <span class="font-semibold">目標：</span>
-      <span><%= current_user.profile.goal %></span>
+      <% if current_user.profile.event == "sprint" ||  current_user.profile.event == "middle_and_long"%>
+        <span><%= current_user.profile.goal.to_s.gsub('.', '秒') %></span>
+      <% else %>
+        <span><%= current_user.profile.goal.to_s.gsub('.', 'm') %></span>
+      <% end %>
     </div>
     <div>
       <span class="font-semibold">自己紹介：</span>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,5 @@
 <div class="bg-white shadow-lg rounded-lg p-6 w-full max-w-lg mx-auto mt-4">
-  <%= link_to "ログアウト", destroy_user_session_path, data: { 'turbo-method': :delete} %>
+  <%= link_to "ログアウト", destroy_user_session_path, data: { 'turbo-method': :delete}, class: "" %>
   <h2 class="text-xl font-bold text-center border-b pb-2 mb-4">プロフィール</h2>
 
   <div class="space-y-4">
@@ -38,7 +38,7 @@
   </div>
 </div>
 <br>
-<div data-controller="select-event" class="bg-white shadow-lg rounded-lg p-6 w-full max-w-lg mx-auto">
+<div class="bg-white shadow-lg rounded-lg p-6 w-full max-w-lg mx-auto">
   <h2 class="text-xl font-bold text-center border-b pb-2 mb-4">いいねを送った投稿</h2>
     <div class="flex gap-2 items-center justify-center">
       <%= link_to "一覧へ", liked_posts_user_path(@user)  ,class: "font-semibold inline-block bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 transition" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="flex bg-gray-400 h-16 p-6 justify-between">
   <%= link_to posts_path do%>
-    <div class="top-10">ヘッダー</div>
+    <div class="top-10">陸ログ</div>
   <% end %>
 
   <% if @profile&.id.present? %>

--- a/db/migrate/20250319061236_add_content_to_post.rb
+++ b/db/migrate/20250319061236_add_content_to_post.rb
@@ -1,5 +1,5 @@
 class AddContentToPost < ActiveRecord::Migration[7.2]
   def change
-    add_column :posts, :content, :text, null: false
+    add_column :posts, :content, :text, null: false, default: ""
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,7 +98,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_22_025839) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.text "content", null: false
+    t.text "content", default: "", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
***
アプリケーションのレイアウト調整と軽微なエラーの修正を行いました。

### 変更内容
***

- ヘッダーにアプリ名の設定
- `post`の`content`にデフォルト値を設定
- `profile`の専門種目選択フォームの変更
- `profile`の目標記録を選択した専門種目に応じて「秒」 or「 m」で表示するように変更

### 確認方法
***
- アプリ名設定を確認
    - アプリケーションのヘッダーに正しいアプリ名が表示されていることを確認 

- profileの専門種目選択フォーム確認
    - プロフィールページで「専門種目」を選択するフォームが適切に表示され、選択肢が動作することを確認 

-  目標記録の単位の変更確認
    - プロフィールページで専門種目に応じて、目標記録が「秒」または「m」で正しく表示されていることを確認